### PR TITLE
Correct OTA file parser header length check

### DIFF
--- a/AirocBluetoothConnectApp/Classes/ViewControllers/OTA/OTAFileParser.m
+++ b/AirocBluetoothConnectApp/Classes/ViewControllers/OTA/OTAFileParser.m
@@ -77,7 +77,7 @@
             fileContentsArray = [self removeEmptyRowsAndJunkDataFromArray:fileContentsArray];
             NSString * fileHeader = [fileContentsArray objectAtIndex:0];
             
-            if (fileHeader.length >= FILE_HEADER_MAX_LENGTH)
+            if (fileHeader.length <= FILE_HEADER_MAX_LENGTH)
             {
                 //Parse header
                 [fileHeaderDict setObject:[NSNumber numberWithInt:iFileVersionTypeCYACD] forKey:FILE_VERSION];//Version of 0 for CYACD files


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.

I discovered this while manually reviewing the code to understand the OTA process. It looks like this was never caught because the header is usually always equal to the max header size. But the sign on this statement appears to be backwards to how the code is written. Either the sign needs to be flipped of the variable names need to be changed to reflect that.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.